### PR TITLE
Test coverage: added sbt plugin to generate scoverage reports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,3 +25,10 @@ libraryDependencies ++= Seq(
 )
 
 coverageEnabled := true
+
+lazy val tdlTests = taskKey[Unit]("Run tests for CI")
+
+tdlTests := {
+  // Capture the test result
+  val testResult = (test in Test).result.value
+}

--- a/build.sbt
+++ b/build.sbt
@@ -23,3 +23,5 @@ libraryDependencies ++= Seq(
   unirest,
   scalatest
 )
+
+jacocoReportSettings := JacocoReportSettings(title = "Report Title", formats = Seq(JacocoReportFormats.XML))

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,4 @@ libraryDependencies ++= Seq(
   scalatest
 )
 
-jacocoReportSettings := JacocoReportSettings(title = "Report Title", formats = Seq(JacocoReportFormats.XML))
-
-showSuccess := false
+coverageEnabled := true

--- a/build.sbt
+++ b/build.sbt
@@ -25,3 +25,5 @@ libraryDependencies ++= Seq(
 )
 
 jacocoReportSettings := JacocoReportSettings(title = "Report Title", formats = Seq(JacocoReportFormats.XML))
+
+showSuccess := false

--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -8,11 +8,14 @@ SCRIPT_CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 CHALLENGE_ID=$1
 JACOCO_TEST_REPORT_XML_FILE="${SCRIPT_CURRENT_DIR}/target/scala-2.12/jacoco/report/jacoco.xml"
+SCALA_COVERAGE_INFO="${SCRIPT_CURRENT_DIR}/target/scala-code-coverage.txt"
 
-sbt --error clean jacoco || true 1>&2
+sbt clean jacoco || true 1>&2
+
+[ -e ${SCALA_COVERAGE_INFO} ] && rm ${SCALA_COVERAGE_INFO}
 
 #
-# TODO: when one or more tests fails the jacoco coverage xml isn't created so we return 0.
+# TODO: when one or more tests fails the jacoco coverage xml isn't created so we return nothing and exit with error code of -1.
 #       This is a work-around in case of missing coverage xml file.
 #       Proper solution would be to capture the results of the failing task and do nothing and proceed with execution
 #       Something to pick up at a later stage.
@@ -23,7 +26,9 @@ if [ -f "${JACOCO_TEST_REPORT_XML_FILE}" ]; then
     COVERED=$(echo $COVERAGE_OUTPUT | awk '{print missed, $4}' | tr '="' ' '| awk '{print $2}')
 
     TOTAL_LINES=$((MISSED + $COVERED))
-    echo $(($COVERED * 100 / $TOTAL_LINES))
+    echo $(($COVERED * 100 / $TOTAL_LINES)) > ${SCALA_COVERAGE_INFO}
+    cat ${SCALA_COVERAGE_INFO}
+    exit 0
 else
-    echo 0
+    exit -1
 fi

--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -9,11 +9,21 @@ SCRIPT_CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHALLENGE_ID=$1
 JACOCO_TEST_REPORT_XML_FILE="${SCRIPT_CURRENT_DIR}/target/scala-2.12/jacoco/report/jacoco.xml"
 
-sbt --error clean test jacoco || true 1>&2
+sbt --error clean jacoco || true 1>&2
 
-COVERAGE_OUTPUT=$(xmllint --xpath '//package[@name="befaster/solutions/'${CHALLENGE_ID}'"]/counter[@type="INSTRUCTION"]' ${JACOCO_TEST_REPORT_XML_FILE})
-MISSED=$(echo $COVERAGE_OUTPUT | awk '{print missed, $3}' | tr '="' ' ' | awk '{print $2}')
-COVERED=$(echo $COVERAGE_OUTPUT | awk '{print missed, $4}' | tr '="' ' '| awk '{print $2}')
+#
+# TODO: when one or more tests fails the jacoco coverage xml isn't created so we return 0.
+#       This is a work-around in case of missing coverage xml file.
+#       Proper solution would be to capture the results of the failing task and do nothing and proceed with execution
+#       Something to pick up at a later stage.
+#
+if [ -f "${JACOCO_TEST_REPORT_XML_FILE}" ]; then
+    COVERAGE_OUTPUT=$(xmllint --xpath '//package[@name="befaster/solutions/'${CHALLENGE_ID}'"]/counter[@type="INSTRUCTION"]' ${JACOCO_TEST_REPORT_XML_FILE})
+    MISSED=$(echo $COVERAGE_OUTPUT | awk '{print missed, $3}' | tr '="' ' ' | awk '{print $2}')
+    COVERED=$(echo $COVERAGE_OUTPUT | awk '{print missed, $4}' | tr '="' ' '| awk '{print $2}')
 
-TOTAL_LINES=$((MISSED + $COVERED))
-echo $(($COVERED * 100 / $TOTAL_LINES))
+    TOTAL_LINES=$((MISSED + $COVERED))
+    echo $(($COVERED * 100 / $TOTAL_LINES))
+else
+    echo 0
+fi

--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+SCRIPT_CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+CHALLENGE_ID=$1
+JACOCO_TEST_REPORT_XML_FILE="${SCRIPT_CURRENT_DIR}/target/scala-2.12/jacoco/report/jacoco.xml"
+
+sbt --error clean test jacoco || true 1>&2
+
+COVERAGE_OUTPUT=$(xmllint --xpath '//package[@name="befaster/solutions/'${CHALLENGE_ID}'"]/counter[@type="INSTRUCTION"]' ${JACOCO_TEST_REPORT_XML_FILE})
+MISSED=$(echo $COVERAGE_OUTPUT | awk '{print missed, $3}' | tr '="' ' ' | awk '{print $2}')
+COVERED=$(echo $COVERAGE_OUTPUT | awk '{print missed, $4}' | tr '="' ' '| awk '{print $2}')
+
+TOTAL_LINES=$((MISSED + $COVERED))
+echo $(($COVERED * 100 / $TOTAL_LINES))

--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -x
 set -e
 set -u
 set -o pipefail
@@ -10,18 +11,18 @@ CHALLENGE_ID=$1
 SCOVERAGE_REPORT_XML_FILE="${SCRIPT_CURRENT_DIR}/target/scala-2.12/scoverage-report/scoverage.xml"
 SCALA_CODE_COVERAGE_INFO="${SCRIPT_CURRENT_DIR}/target/scala-code-coverage.txt"
 
-sbt clean coverage test || true 1>&2
-sbt coverageReport || true 1>&2
+sbt clean coverage tdlTests coverageReport || true
 
 [ -e ${SCALA_CODE_COVERAGE_INFO} ] && rm ${SCALA_CODE_COVERAGE_INFO}
 
 if [ -f "${SCOVERAGE_REPORT_XML_FILE}" ]; then
     COVERAGE_OUTPUT=$(xmllint --xpath '//package[@name="befaster.solutions.'${CHALLENGE_ID}'"]/@statement-rate' ${SCOVERAGE_REPORT_XML_FILE})
-    COVERAGE_PERCENT=$(echo ${COVERAGE_OUTPUT} | tr '".' ' ' | awk '{print $2}')
-    COVERAGE_PERCENT=$(expr ${COVERAGE_PERCENT})
+    COVERAGE_PERCENT=$(echo ${COVERAGE_OUTPUT} | tr '".' ' ' | tr -s ' ' | awk '{print $2}')
+    COVERAGE_PERCENT=$(( ${COVERAGE_PERCENT} + 0 ))
     echo ${COVERAGE_PERCENT} > ${SCALA_CODE_COVERAGE_INFO}
     cat ${SCALA_CODE_COVERAGE_INFO}
     exit 0
 else
+    echo "No coverage report was found"
     exit -1
 fi

--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -7,27 +7,20 @@ set -o pipefail
 SCRIPT_CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 CHALLENGE_ID=$1
-JACOCO_TEST_REPORT_XML_FILE="${SCRIPT_CURRENT_DIR}/target/scala-2.12/jacoco/report/jacoco.xml"
-SCALA_COVERAGE_INFO="${SCRIPT_CURRENT_DIR}/target/scala-code-coverage.txt"
+SCOVERAGE_REPORT_XML_FILE="${SCRIPT_CURRENT_DIR}/target/scala-2.12/scoverage-report/scoverage.xml"
+SCALA_CODE_COVERAGE_INFO="${SCRIPT_CURRENT_DIR}/target/scala-code-coverage.txt"
 
-sbt clean jacoco || true 1>&2
+sbt clean coverage test || true 1>&2
+sbt coverageReport || true 1>&2
 
-[ -e ${SCALA_COVERAGE_INFO} ] && rm ${SCALA_COVERAGE_INFO}
+[ -e ${SCALA_CODE_COVERAGE_INFO} ] && rm ${SCALA_CODE_COVERAGE_INFO}
 
-#
-# TODO: when one or more tests fails the jacoco coverage xml isn't created so we return nothing and exit with error code of -1.
-#       This is a work-around in case of missing coverage xml file.
-#       Proper solution would be to capture the results of the failing task and do nothing and proceed with execution
-#       Something to pick up at a later stage.
-#
-if [ -f "${JACOCO_TEST_REPORT_XML_FILE}" ]; then
-    COVERAGE_OUTPUT=$(xmllint --xpath '//package[@name="befaster/solutions/'${CHALLENGE_ID}'"]/counter[@type="INSTRUCTION"]' ${JACOCO_TEST_REPORT_XML_FILE})
-    MISSED=$(echo $COVERAGE_OUTPUT | awk '{print missed, $3}' | tr '="' ' ' | awk '{print $2}')
-    COVERED=$(echo $COVERAGE_OUTPUT | awk '{print missed, $4}' | tr '="' ' '| awk '{print $2}')
-
-    TOTAL_LINES=$((MISSED + $COVERED))
-    echo $(($COVERED * 100 / $TOTAL_LINES)) > ${SCALA_COVERAGE_INFO}
-    cat ${SCALA_COVERAGE_INFO}
+if [ -f "${SCOVERAGE_REPORT_XML_FILE}" ]; then
+    COVERAGE_OUTPUT=$(xmllint --xpath '//package[@name="befaster.solutions.'${CHALLENGE_ID}'"]/@statement-rate' ${SCOVERAGE_REPORT_XML_FILE})
+    COVERAGE_PERCENT=$(echo ${COVERAGE_OUTPUT} | tr '".' ' ' | awk '{print $2}')
+    COVERAGE_PERCENT=$(expr ${COVERAGE_PERCENT})
+    echo ${COVERAGE_PERCENT} > ${SCALA_CODE_COVERAGE_INFO}
+    cat ${SCALA_CODE_COVERAGE_INFO}
     exit 0
 else
     exit -1

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 logLevel := Level.Warn
 
-addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.0.3")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 logLevel := Level.Warn
+
+addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.0.3")

--- a/project/project/build.properties
+++ b/project/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.4

--- a/src/main/scala/befaster/ConnectToServer.scala
+++ b/src/main/scala/befaster/ConnectToServer.scala
@@ -3,7 +3,10 @@ package befaster
 import befaster.runner.TypeConversion.asInt
 import befaster.runner.UserInputAction
 import befaster.runner.Utils.{getConfig, getRunnerConfig}
-import befaster.solutions.{Checkout, FizzBuzz, Hello, Sum}
+import befaster.solutions.CHK.Checkout
+import befaster.solutions.FIZ.FizzBuzz
+import befaster.solutions.HLO.Hello
+import befaster.solutions.SUM.Sum
 import tdl.client.queue.QueueBasedImplementationRunner
 import tdl.client.runner.ChallengeSession
 

--- a/src/main/scala/befaster/solutions/CHK/Checkout.scala
+++ b/src/main/scala/befaster/solutions/CHK/Checkout.scala
@@ -1,4 +1,4 @@
-package befaster.solutions
+package befaster.solutions.CHK
 
 import befaster.runner.SolutionNotImplementedException
 

--- a/src/main/scala/befaster/solutions/FIZ/FizzBuzz.scala
+++ b/src/main/scala/befaster/solutions/FIZ/FizzBuzz.scala
@@ -1,4 +1,4 @@
-package befaster.solutions
+package befaster.solutions.FIZ
 
 import befaster.runner.SolutionNotImplementedException
 

--- a/src/main/scala/befaster/solutions/HLO/Hello.scala
+++ b/src/main/scala/befaster/solutions/HLO/Hello.scala
@@ -1,4 +1,4 @@
-package befaster.solutions
+package befaster.solutions.HLO
 
 import befaster.runner.SolutionNotImplementedException
 

--- a/src/main/scala/befaster/solutions/SUM/Sum.scala
+++ b/src/main/scala/befaster/solutions/SUM/Sum.scala
@@ -1,4 +1,4 @@
-package befaster.solutions
+package befaster.solutions.SUM
 
 import befaster.runner.SolutionNotImplementedException
 

--- a/src/test/scala/befaster/solutions/SUM/SumTest.scala
+++ b/src/test/scala/befaster/solutions/SUM/SumTest.scala
@@ -1,4 +1,4 @@
-package befaster.solutions
+package befaster.solutions.SUM
 
 import org.scalatest.{FlatSpec, Matchers}
 


### PR DESCRIPTION
Test coverage: added sbt plugin to generate scoverage reports can be invoked via the 'sbt clean jacocoReport test' command.

The above command generates the below info in the console:
```
[info] Lines: 0% (>= required 0.0%) covered, 0 of 0 missed, OK
[info] Instructions: 0% (>= required 0.0%) covered, 0 of 0 missed, OK
[info] Branches: 0% (>= required 0.0%) covered, 0 of 0 missed, OK
[info] Methods: 0% (>= required 0.0%) covered, 0 of 0 missed, OK
[info] Complexity: 0% (>= required 0.0%) covered, 0 of 0 missed, OK
[info] Class: 0% (>= required 0.0%) covered, 0 of 0 missed, OK
```
Will need to dig into how to generate a .csv files with breaddown of package level line coverage - TODO.

Initial steps towards getting the line coverage per package.

All scripts in place to get coverage and save it into a text file inside `target` folder.

Target command to run (example):
```
./get_coverage_for_challenge.sh SUM
```