### PR TITLE
Fixed an edge-case to return 0

### DIFF
--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -16,9 +16,12 @@ SCALA_CODE_COVERAGE_INFO="${SCRIPT_CURRENT_DIR}/coverage.tdl"
 [ -e ${SCALA_CODE_COVERAGE_INFO} ] && rm ${SCALA_CODE_COVERAGE_INFO}
 
 if [ -f "${SCOVERAGE_REPORT_XML_FILE}" ]; then
-    COVERAGE_OUTPUT=$(xmllint --xpath '//package[@name="befaster.solutions.'${CHALLENGE_ID}'"]/@statement-rate' ${SCOVERAGE_REPORT_XML_FILE})
-    COVERAGE_PERCENT=$(echo ${COVERAGE_OUTPUT} | tr '".' ' ' | tr -s ' ' | awk '{print $2}')
-    COVERAGE_PERCENT=$(( ${COVERAGE_PERCENT} + 0 ))
+    COVERAGE_OUTPUT=$(xmllint --xpath '//package[@name="befaster.solutions.'${CHALLENGE_ID}'"]/@statement-rate' ${SCOVERAGE_REPORT_XML_FILE} || true)
+    COVERAGE_PERCENT=$(( 0 ))
+    if [[ ! -z "${COVERAGE_OUTPUT}" ]]; then
+        COVERAGE_PERCENT=$(echo ${COVERAGE_OUTPUT} | tr '".' ' ' | tr -s ' ' | awk '{print $2}')
+        COVERAGE_PERCENT=$(( ${COVERAGE_PERCENT} + 0 ))
+    fi
     echo ${COVERAGE_PERCENT} > ${SCALA_CODE_COVERAGE_INFO}
     cat ${SCALA_CODE_COVERAGE_INFO}
     exit 0


### PR DESCRIPTION
Fixed an edge-case to return 0 when the challenge_id passed in has no tests at all or the challenge_id is incorrect/does not exists

I have tested the change against these three scenarios:
- SUM
- CHK
- S
- CH

All seems to work as expected.